### PR TITLE
ci: add mandatory PostgreSQL/PostGIS production gate

### DIFF
--- a/.github/workflows/postgres-postgis.yml
+++ b/.github/workflows/postgres-postgis.yml
@@ -1,0 +1,53 @@
+name: PostgreSQL / PostGIS
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: postgres-postgis-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  postgres-postgis:
+    name: PostgreSQL 13 / PostGIS integration
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    services:
+      postgres:
+        image: postgis/postgis:13-master
+        env:
+          POSTGRES_DB: terrastories_test
+          POSTGRES_USER: terrastories
+          POSTGRES_HOST_AUTH_METHOD: trust
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U terrastories -d terrastories_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+
+    env:
+      NODE_ENV: test
+      DATABASE_URL: postgresql://terrastories@127.0.0.1:5432/terrastories_test
+      ALLOW_POSTGRES_TEST_RESET: 'true'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run PostgreSQL/PostGIS production gate
+        run: npm run test:postgres

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,8 +78,9 @@ WORKDIR /app
 # Create uploads directory with proper permissions
 RUN mkdir -p uploads && chown -R terrastories:nodejs uploads
 
-# Copy built application from builder stage
+# Copy built application and runtime migration assets from builder stage
 COPY --from=builder --chown=terrastories:nodejs /app/dist ./dist
+COPY --from=builder --chown=terrastories:nodejs /app/src/db/migrations ./dist/db/migrations
 COPY --from=builder --chown=terrastories:nodejs /app/node_modules ./node_modules
 COPY --chown=terrastories:nodejs package*.json ./
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -54,7 +54,7 @@ services:
       start_period: 30s
     restart: unless-stopped
     # Security: run database migrations on startup
-    command: sh -c "npm run db:migrate && npm start"
+    command: sh -c "node dist/db/migrate.js && npm start"
 
   # =============================================================================
   # DATABASE SERVICE - Production Configuration

--- a/docs/development/postgresql-postgis-ci.md
+++ b/docs/development/postgresql-postgis-ci.md
@@ -1,0 +1,77 @@
+# PostgreSQL/PostGIS production gate
+
+Terrastories uses SQLite for fast local development and many unit tests, but production database behavior must be validated against PostgreSQL with PostGIS. SQLite success is not evidence that PostgreSQL migrations, constraints, data types, spatial queries, or indexes are safe.
+
+The `PostgreSQL / PostGIS` GitHub Actions workflow runs for every pull request targeting `main` and every push to `main`. It uses the same PostgreSQL major/image family as the production Compose configuration: `postgis/postgis:13-master`.
+
+## What the gate validates
+
+`npm run test:postgres` is destructive and runs only against a database whose name contains `test` and when `ALLOW_POSTGRES_TEST_RESET=true` is explicitly set. The gate covers four production-relevant paths:
+
+1. **Fresh install** — resets an empty PostgreSQL database, enables PostGIS, runs the production migration history, validates schema catalogs, and reruns migrations to prove startup idempotency.
+2. **Fail-closed migration** — loads the previous-release schema and a sanitized production-like fixture, deliberately introduces an invalid coordinate, and verifies the migration fails and is not recorded as applied.
+3. **Previous-release upgrade** — migrates the previous-release schema plus representative data and checks that ownership, restricted/elder flags, file metadata and cultural restrictions, story-place/story-speaker joins, and authentication state survive unchanged.
+4. **Application repository behavior** — exercises community and place repositories against PostgreSQL, including restricted-place filtering and radius search using real PostGIS.
+
+The catalog checks verify representative production requirements including foreign keys, uniqueness, coordinate and role constraints, defaults, Rails-compatible timestamp columns, Rails compatibility/authentication fields, the generated `geometry(Point, 4326)` location column, and both geometry and geography GiST indexes.
+
+The spatial check executes `ST_DWithin` against real PostGIS and inspects `EXPLAIN` with sequential scans disabled to prove the geography GiST index can serve the production radius predicate.
+
+## Local reproduction
+
+Start an ephemeral PostgreSQL/PostGIS service. This uses trust authentication only for the disposable local test container; never use it for a deployed database.
+
+```sh
+docker run --rm --name terrastories-postgres-test \
+  -e POSTGRES_DB=terrastories_test \
+  -e POSTGRES_USER=terrastories \
+  -e POSTGRES_HOST_AUTH_METHOD=trust \
+  -p 55432:5432 \
+  postgis/postgis:13-master
+```
+
+In another terminal:
+
+```sh
+DATABASE_URL=postgresql://terrastories@127.0.0.1:55432/terrastories_test \
+ALLOW_POSTGRES_TEST_RESET=true \
+npm run test:postgres
+```
+
+The test runner drops and recreates the `public` and `drizzle` schemas. It refuses to run unless the database name contains `test` and the reset acknowledgement is present.
+
+## Migration layout
+
+SQLite and PostgreSQL have separate runtime migration histories because SQL emitted for one dialect is not safely executable by the other:
+
+- `src/db/migrations/` contains the existing SQLite migration history used by the local/test SQLite path.
+- `src/db/migrations/postgres/` contains reviewed PostgreSQL/PostGIS production migrations and its own Drizzle migration journal.
+
+`src/db/migrate.ts` chooses the migration history from `DATABASE_URL`. PostgreSQL migration startup is fail-closed: if PostGIS cannot be enabled or verified, the migration command exits non-zero rather than silently degrading spatial behavior.
+
+The production image copies the reviewed SQL migration assets into `dist/db/migrations`, next to the compiled migrator. `docker-compose.prod.yml` runs `node dist/db/migrate.js` before `npm start`, so production does not depend on the development-only `tsx` runner or on source files that are absent from the runtime image.
+
+Production migration changes must include a matching PostgreSQL gate update whenever they alter tables, relationships, defaults, indexes, spatial behavior, or migration invariants.
+
+## Sanitized migration fixtures
+
+Files under `tests/fixtures/postgres/` are synthetic and must remain free of real community, user, territorial, authentication, or cultural data. Add only the minimum representative fields needed to prove migration invariants.
+
+When a migration changes data semantics, update the previous-release schema fixture and production-like fixture so CI demonstrates both the old state and the expected post-migration state. Sensitive-looking fields must use explicit redacted placeholders.
+
+## Expand-contract policy
+
+Production schema changes should be deployable without requiring an unsafe all-at-once cutover.
+
+1. **Expand**: add compatible columns, indexes, or relationships first. Prefer nullable columns or safe defaults when existing rows need a backfill. Preserve old reads/writes while both schemas can coexist.
+2. **Backfill and validate**: migrate existing rows in bounded, observable steps. Validate invariants before adding constraints that could reject legacy data. For large tables, choose PostgreSQL techniques that avoid unnecessarily long locks.
+3. **Switch application behavior**: deploy code that reads/writes the expanded schema only after the backfill and validation are complete.
+4. **Contract later**: remove obsolete columns, indexes, compatibility writes, or legacy semantics in a later deployment after rollback no longer depends on them.
+
+Treat destructive operations as separate migrations with an explicit recovery plan. Do not combine column/table drops, incompatible type narrowing, irreversible data rewrites, or new `NOT NULL`/foreign-key assumptions with the first deployment that depends on them. A migration that discovers invalid production-like data must fail before being recorded as applied.
+
+For changes that can affect community ownership, access restrictions, cultural protocols, authentication state, file relationships, or story associations, add explicit data-invariant assertions to the PostgreSQL gate before merge.
+
+## CI troubleshooting
+
+A passing SQLite suite does not waive a PostgreSQL failure. Reproduce the PostgreSQL job locally with the commands above and fix the production path. Do not weaken the gate by skipping PostGIS checks, swallowing migration errors, changing assertions to warnings, or replacing production fixtures with mocks.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "start": "node dist/server.js",
     "test": "vitest",
     "test:coverage": "vitest run --coverage",
+    "test:postgres": "tsx scripts/test-postgres-ci.ts",
     "test:ci": "node scripts/test-ci.js",
     "lint": "eslint .",
     "format": "prettier --write .",

--- a/scripts/test-postgres-ci.ts
+++ b/scripts/test-postgres-ci.ts
@@ -1,0 +1,565 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import postgres from 'postgres';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import { CommunityRepository } from '../src/repositories/community.repository.js';
+import { PlaceRepository } from '../src/repositories/place.repository.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const rootDir = path.resolve(path.dirname(__filename), '..');
+process.env.NODE_ENV = 'test';
+const databaseUrl = process.env.DATABASE_URL;
+
+if (!databaseUrl) {
+  throw new Error('DATABASE_URL is required for PostgreSQL integration tests');
+}
+
+const parsedDatabaseUrl = new URL(databaseUrl);
+const databaseName = parsedDatabaseUrl.pathname.replace(/^\//, '');
+if (!/test/i.test(databaseName)) {
+  throw new Error(
+    `Refusing destructive PostgreSQL integration tests against non-test database: ${databaseName}`
+  );
+}
+
+if (process.env.ALLOW_POSTGRES_TEST_RESET !== 'true') {
+  throw new Error(
+    'Set ALLOW_POSTGRES_TEST_RESET=true to acknowledge the PostgreSQL test database will be reset'
+  );
+}
+
+const sql = postgres(databaseUrl, {
+  max: 2,
+  prepare: false,
+  onnotice: () => undefined,
+});
+
+async function executeSqlFixture(relativePath: string): Promise<void> {
+  const source = await readFile(path.join(rootDir, relativePath), 'utf8');
+  const statements = source
+    .split('--> statement-breakpoint')
+    .map((statement) => statement.trim())
+    .filter(Boolean);
+
+  for (const statement of statements) {
+    await sql.unsafe(statement);
+  }
+}
+
+async function resetDatabase(): Promise<void> {
+  await sql.unsafe('DROP SCHEMA IF EXISTS drizzle CASCADE');
+  await sql.unsafe('DROP SCHEMA IF EXISTS public CASCADE');
+  await sql.unsafe('CREATE SCHEMA public');
+}
+
+function runMigration(expectSuccess: boolean): void {
+  const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+  const result = spawnSync(npmCommand, ['run', 'db:migrate'], {
+    cwd: rootDir,
+    env: {
+      ...process.env,
+      NODE_ENV: 'test',
+      DATABASE_URL: databaseUrl,
+    },
+    encoding: 'utf8',
+  });
+
+  const output = `${result.stdout ?? ''}${result.stderr ?? ''}`;
+  if (expectSuccess) {
+    assert.equal(
+      result.status,
+      0,
+      `PostgreSQL migration was expected to succeed:\n${output}`
+    );
+    assert.match(output, /Spatial Support: ✅/);
+    return;
+  }
+
+  assert.notEqual(
+    result.status,
+    0,
+    'Migration unexpectedly succeeded for a fixture that violates a production constraint'
+  );
+  assert.match(output, /Migration failed/);
+}
+
+async function verifyFreshSchema(): Promise<void> {
+  const [postgis] = await sql<{ version: string }[]>`
+    SELECT PostGIS_Version() AS version
+  `;
+  assert.ok(postgis.version.length > 0, 'PostGIS must be available');
+
+  const columns = await sql<
+    {
+      table_name: string;
+      column_name: string;
+      data_type: string;
+      udt_name: string;
+      is_nullable: string;
+      column_default: string | null;
+      is_generated: string;
+    }[]
+  >`
+    SELECT
+      table_name,
+      column_name,
+      data_type,
+      udt_name,
+      is_nullable,
+      column_default,
+      is_generated
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+  `;
+
+  const byColumn = new Map(
+    columns.map((column) => [
+      `${column.table_name}.${column.column_name}`,
+      column,
+    ])
+  );
+
+  for (const requiredColumn of [
+    'communities.country',
+    'communities.beta',
+    'users.reset_password_token',
+    'users.reset_password_sent_at',
+    'users.remember_created_at',
+    'users.sign_in_count',
+    'users.last_sign_in_at',
+    'users.current_sign_in_ip',
+    'places.location',
+    'stories.privacy_level',
+    'stories.image_url',
+    'stories.audio_url',
+    'speakers.bio_audio_url',
+    'story_places.cultural_context',
+    'story_speakers.story_role',
+  ]) {
+    assert.ok(byColumn.has(requiredColumn), `Missing column ${requiredColumn}`);
+  }
+
+  const location = byColumn.get('places.location');
+  assert.equal(location?.udt_name, 'geometry');
+  assert.equal(location?.is_generated, 'ALWAYS');
+
+  for (const timestampColumn of [
+    'communities.created_at',
+    'communities.updated_at',
+    'users.created_at',
+    'users.updated_at',
+    'places.created_at',
+    'places.updated_at',
+    'stories.created_at',
+    'stories.updated_at',
+  ]) {
+    const column = byColumn.get(timestampColumn);
+    assert.equal(
+      column?.data_type,
+      'timestamp without time zone',
+      `${timestampColumn} must remain Rails-compatible timestamp data`
+    );
+    assert.equal(column?.is_nullable, 'NO');
+    assert.ok(column?.column_default, `${timestampColumn} needs a default`);
+  }
+
+  const indexes = await sql<{ indexname: string; indexdef: string }[]>`
+    SELECT indexname, indexdef
+    FROM pg_indexes
+    WHERE schemaname = 'public'
+  `;
+  const indexNames = new Set(indexes.map((index) => index.indexname));
+  for (const requiredIndex of [
+    'communities_slug_unique',
+    'users_email_community_unique',
+    'places_community_id_idx',
+    'places_location_gist_idx',
+    'places_location_geography_gist_idx',
+    'speakers_elder_status_idx',
+    'stories_privacy_level_idx',
+    'files_community_idx',
+    'story_place_unique',
+    'story_speaker_unique',
+  ]) {
+    assert.ok(indexNames.has(requiredIndex), `Missing index ${requiredIndex}`);
+  }
+}
+
+async function verifyConstraintsAndDefaults(): Promise<void> {
+  const constraints = await sql<{ conname: string; definition: string }[]>`
+    SELECT conname, pg_get_constraintdef(oid) AS definition
+    FROM pg_constraint
+    WHERE connamespace = 'public'::regnamespace
+  `;
+  const constraintsByName = new Map(
+    constraints.map((constraint) => [constraint.conname, constraint])
+  );
+
+  for (const requiredConstraint of [
+    'communities_country_iso_check',
+    'users_community_id_fkey',
+    'users_role_check',
+    'places_community_id_fkey',
+    'places_latitude_check',
+    'places_longitude_check',
+    'stories_community_id_fkey',
+    'stories_created_by_fkey',
+    'files_community_id_fkey',
+    'files_uploaded_by_fkey',
+    'story_places_story_id_fkey',
+    'story_places_place_id_fkey',
+    'story_speakers_story_id_fkey',
+    'story_speakers_speaker_id_fkey',
+  ]) {
+    assert.ok(
+      constraintsByName.has(requiredConstraint),
+      `Missing constraint ${requiredConstraint}`
+    );
+  }
+
+  assert.match(
+    constraintsByName.get('story_places_story_id_fkey')?.definition ?? '',
+    /ON DELETE CASCADE/
+  );
+  assert.match(
+    constraintsByName.get('story_speakers_story_id_fkey')?.definition ?? '',
+    /ON DELETE CASCADE/
+  );
+
+  const [defaults] = await sql<
+    {
+      public_stories: boolean;
+      locale: string;
+      is_active: boolean;
+      beta: boolean;
+      created_at: Date;
+      updated_at: Date;
+    }[]
+  >`
+    INSERT INTO communities (name, slug)
+    VALUES ('Fresh Defaults', 'fresh-defaults-' || floor(random() * 1000000)::text)
+    RETURNING public_stories, locale, is_active, beta, created_at, updated_at
+  `;
+  assert.equal(defaults.public_stories, false);
+  assert.equal(defaults.locale, 'en');
+  assert.equal(defaults.is_active, true);
+  assert.equal(defaults.beta, false);
+  assert.ok(defaults.created_at instanceof Date);
+  assert.ok(defaults.updated_at instanceof Date);
+}
+
+async function verifyUpgradeDataInvariants(): Promise<void> {
+  const [community] = await sql<
+    {
+      id: number;
+      country: string;
+      beta: boolean;
+      locale: string;
+      is_active: boolean;
+    }[]
+  >`
+    SELECT id, country, beta, locale, is_active
+    FROM communities
+    WHERE id = 1
+  `;
+  assert.deepEqual(community, {
+    id: 1,
+    country: 'BR',
+    beta: true,
+    locale: 'en',
+    is_active: true,
+  });
+
+  const [user] = await sql<
+    {
+      community_id: number;
+      reset_password_token: string;
+      sign_in_count: number;
+      current_sign_in_ip: string;
+    }[]
+  >`
+    SELECT community_id, reset_password_token, sign_in_count, current_sign_in_ip
+    FROM users
+    WHERE id = 1
+  `;
+  assert.equal(user.community_id, 1);
+  assert.equal(user.reset_password_token, '[REDACTED_TOKEN]');
+  assert.equal(user.sign_in_count, 7);
+  assert.equal(user.current_sign_in_ip, '192.0.2.10');
+
+  const [place] = await sql<
+    {
+      community_id: number;
+      is_restricted: boolean;
+      srid: number;
+      geometry_type: string;
+    }[]
+  >`
+    SELECT
+      community_id,
+      is_restricted,
+      ST_SRID(location) AS srid,
+      GeometryType(location) AS geometry_type
+    FROM places
+    WHERE id = 1
+  `;
+  assert.equal(place.community_id, 1);
+  assert.equal(place.is_restricted, true);
+  assert.equal(place.srid, 4326);
+  assert.equal(place.geometry_type, 'POINT');
+
+  const [speaker] = await sql<
+    { community_id: number; elder_status: boolean }[]
+  >`SELECT community_id, elder_status FROM speakers WHERE id = 1`;
+  assert.deepEqual(speaker, { community_id: 1, elder_status: true });
+
+  const [story] = await sql<
+    { community_id: number; created_by: number; is_restricted: boolean }[]
+  >`SELECT community_id, created_by, is_restricted FROM stories WHERE id = 1`;
+  assert.deepEqual(story, {
+    community_id: 1,
+    created_by: 1,
+    is_restricted: true,
+  });
+
+  const [file] = await sql<
+    {
+      community_id: number;
+      uploaded_by: number;
+      metadata: { duration: number };
+      cultural_restrictions: { elderOnly: boolean; accessLevel: string };
+    }[]
+  >`
+    SELECT community_id, uploaded_by, metadata, cultural_restrictions
+    FROM files
+    WHERE id = '11111111-1111-4111-8111-111111111111'
+  `;
+  assert.equal(file.community_id, 1);
+  assert.equal(file.uploaded_by, 1);
+  assert.equal(file.metadata.duration, 42);
+  assert.equal(file.cultural_restrictions.elderOnly, true);
+  assert.equal(file.cultural_restrictions.accessLevel, 'community');
+
+  const [storyPlace] = await sql<
+    { story_id: number; place_id: number; sort_order: number }[]
+  >`SELECT story_id, place_id, sort_order FROM story_places WHERE id = 1`;
+  assert.deepEqual(storyPlace, { story_id: 1, place_id: 1, sort_order: 0 });
+
+  const [storySpeaker] = await sql<
+    { story_id: number; speaker_id: number; sort_order: number }[]
+  >`SELECT story_id, speaker_id, sort_order FROM story_speakers WHERE id = 1`;
+  assert.deepEqual(storySpeaker, {
+    story_id: 1,
+    speaker_id: 1,
+    sort_order: 0,
+  });
+}
+
+async function verifyConstraintEnforcement(): Promise<void> {
+  await assert.rejects(
+    sql.unsafe(`
+      INSERT INTO users (
+        email, password_hash, first_name, last_name, community_id,
+        created_at, updated_at
+      ) VALUES (
+        'orphan@example.test', '[REDACTED_SECRET]', 'Orphan', 'User', 999999,
+        now(), now()
+      )
+    `),
+    (error: unknown) => (error as { code?: string }).code === '23503'
+  );
+
+  await assert.rejects(
+    sql.unsafe(`
+      INSERT INTO places (
+        name, community_id, latitude, longitude, created_at, updated_at
+      ) VALUES ('Invalid Coordinate', 1, 91, 0, now(), now())
+    `),
+    (error: unknown) => (error as { code?: string }).code === '23514'
+  );
+
+  await assert.rejects(
+    sql.unsafe(`
+      INSERT INTO story_places (story_id, place_id, created_at, updated_at)
+      VALUES (1, 1, now(), now())
+    `),
+    (error: unknown) => (error as { code?: string }).code === '23505'
+  );
+
+  await assert.rejects(
+    sql.unsafe(`UPDATE communities SET country = 'br' WHERE id = 1`),
+    (error: unknown) => (error as { code?: string }).code === '23514'
+  );
+}
+
+async function verifySpatialBehaviorAndIndex(): Promise<void> {
+  const nearby = await sql<{ id: number }[]>`
+    SELECT id
+    FROM places
+    WHERE ST_DWithin(
+      location::geography,
+      ST_SetSRID(ST_MakePoint(-48.4902, -1.4558), 4326)::geography,
+      1000
+    )
+    ORDER BY id
+  `;
+  assert.deepEqual(
+    nearby.map((row) => row.id),
+    [1, 2]
+  );
+
+  await sql.unsafe('SET enable_seqscan = off');
+  const planRows = await sql.unsafe(`
+    EXPLAIN
+    SELECT id
+    FROM places
+    WHERE ST_DWithin(
+      location::geography,
+      ST_SetSRID(ST_MakePoint(-48.4902, -1.4558), 4326)::geography,
+      1000
+    )
+  `);
+  await sql.unsafe('RESET enable_seqscan');
+
+  const plan = planRows
+    .map((row: Record<string, unknown>) => String(row['QUERY PLAN']))
+    .join('\n');
+  assert.match(
+    plan,
+    /places_location_geography_gist_idx/,
+    `Expected PostGIS geography GiST index in query plan:\n${plan}`
+  );
+}
+
+async function verifyRepositoriesOnPostgres(): Promise<void> {
+  const client = postgres(databaseUrl, { max: 1, prepare: false });
+  const database = drizzle(client);
+
+  try {
+    const communityRepository = new CommunityRepository(database as any);
+    const community = await communityRepository.create({
+      name: 'Repository Integration Community',
+      locale: 'en',
+    });
+
+    const placeRepository = new PlaceRepository(database as any);
+    const publicPlace = await placeRepository.create({
+      name: 'Repository Near Public',
+      communityId: community.id,
+      latitude: -1.4558,
+      longitude: -48.4902,
+      isRestricted: false,
+    });
+    const restrictedPlace = await placeRepository.create({
+      name: 'Repository Near Restricted',
+      communityId: community.id,
+      latitude: -1.456,
+      longitude: -48.4901,
+      isRestricted: true,
+    });
+    await placeRepository.create({
+      name: 'Repository Far Public',
+      communityId: community.id,
+      latitude: -3.119,
+      longitude: -60.0217,
+      isRestricted: false,
+    });
+
+    const publicSearch = await placeRepository.searchNear({
+      communityId: community.id,
+      latitude: -1.4558,
+      longitude: -48.4902,
+      radiusKm: 1,
+      page: 1,
+      limit: 20,
+    });
+    assert.deepEqual(
+      publicSearch.data.map((place) => place.id),
+      [publicPlace.id]
+    );
+
+    const unrestrictedSearch = await placeRepository.searchNear({
+      communityId: community.id,
+      latitude: -1.4558,
+      longitude: -48.4902,
+      radiusKm: 1,
+      page: 1,
+      limit: 20,
+      includeRestricted: true,
+    });
+    assert.deepEqual(
+      new Set(unrestrictedSearch.data.map((place) => place.id)),
+      new Set([publicPlace.id, restrictedPlace.id])
+    );
+  } finally {
+    await client.end();
+  }
+}
+
+async function verifyFailedMigrationIsNotRecorded(): Promise<void> {
+  const [migrationTable] = await sql<{ table_name: string | null }[]>`
+    SELECT to_regclass('drizzle.__drizzle_migrations')::text AS table_name
+  `;
+  if (!migrationTable.table_name) return;
+
+  const [migrationCount] = await sql<{ count: number }[]>`
+    SELECT count(*)::int AS count FROM drizzle.__drizzle_migrations
+  `;
+  assert.equal(
+    migrationCount.count,
+    0,
+    'Failed migration must not be recorded as applied'
+  );
+}
+
+async function main(): Promise<void> {
+  console.log('🐘 PostgreSQL/PostGIS integration gate');
+
+  console.log('  1/4 fresh database migration');
+  await resetDatabase();
+  runMigration(true);
+  await verifyFreshSchema();
+  await verifyConstraintsAndDefaults();
+  runMigration(true);
+
+  console.log('  2/4 fail-closed migration probe');
+  await resetDatabase();
+  await executeSqlFixture(
+    'tests/fixtures/postgres/previous-release-schema.sql'
+  );
+  await executeSqlFixture('tests/fixtures/postgres/production-like-data.sql');
+  await sql.unsafe('UPDATE places SET latitude = 999 WHERE id = 1');
+  runMigration(false);
+  await verifyFailedMigrationIsNotRecorded();
+
+  console.log('  3/4 previous-release + production-like upgrade');
+  await resetDatabase();
+  await executeSqlFixture(
+    'tests/fixtures/postgres/previous-release-schema.sql'
+  );
+  await executeSqlFixture('tests/fixtures/postgres/production-like-data.sql');
+  runMigration(true);
+  await verifyFreshSchema();
+  await verifyConstraintsAndDefaults();
+  await verifyUpgradeDataInvariants();
+  await verifyConstraintEnforcement();
+  await verifySpatialBehaviorAndIndex();
+
+  console.log('  4/4 repository behavior on PostgreSQL/PostGIS');
+  await verifyRepositoriesOnPostgres();
+
+  console.log('✅ PostgreSQL/PostGIS integration gate passed');
+}
+
+main()
+  .catch((error) => {
+    console.error('❌ PostgreSQL/PostGIS integration gate failed');
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await sql.end();
+  });

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -91,7 +91,9 @@ export async function testConnection(): Promise<{
           database as ReturnType<typeof drizzlePostgres>
         ).execute('SELECT PostGIS_Version() as version');
 
-        version = (result as any).rows[0]?.version || null;
+        const postgresResult = result as any;
+        const firstRow = postgresResult.rows?.[0] ?? postgresResult[0];
+        version = firstRow?.version || null;
         spatialSupport = !!version;
       } catch {
         spatialSupport = false;

--- a/src/db/migrate.ts
+++ b/src/db/migrate.ts
@@ -25,39 +25,32 @@ async function runMigrations() {
       config.database.url.startsWith('postgresql://') ||
       config.database.url.startsWith('postgres://');
 
-    const migrationsFolder = path.join(__dirname, 'migrations');
+    const sqliteMigrationsFolder = path.join(__dirname, 'migrations');
+    const postgresMigrationsFolder = path.join(
+      __dirname,
+      'migrations',
+      'postgres'
+    );
 
     if (isPostgres) {
       console.log('📊 Running PostgreSQL migrations...');
 
-      // Ensure PostGIS extension is enabled before running migrations
+      // Production spatial support is fail-closed. Continuing without PostGIS
+      // would make a successful startup hide a broken production capability.
       if (config.database.spatialSupport) {
         console.log('🌍 Setting up PostGIS extension...');
-        try {
-          const pgDatabase = database as ReturnType<
-            typeof import('drizzle-orm/postgres-js').drizzle
-          >;
-          await pgDatabase.execute('CREATE EXTENSION IF NOT EXISTS postgis;');
-          await pgDatabase.execute(
-            'CREATE EXTENSION IF NOT EXISTS postgis_topology;'
-          );
-
-          console.log('✅ PostGIS extensions enabled');
-        } catch (error: unknown) {
-          const errorMessage =
-            error instanceof Error ? error.message : 'Unknown error';
-
-          console.warn('⚠️ Could not enable PostGIS extensions:', errorMessage);
-
-          console.warn('   Please ensure PostgreSQL has PostGIS installed');
-        }
+        const pgDatabase = database as ReturnType<
+          typeof import('drizzle-orm/postgres-js').drizzle
+        >;
+        await pgDatabase.execute('CREATE EXTENSION IF NOT EXISTS postgis;');
+        console.log('✅ PostGIS extension enabled');
       }
 
       await migratePostgres(
         database as ReturnType<
           typeof import('drizzle-orm/postgres-js').drizzle
         >,
-        { migrationsFolder }
+        { migrationsFolder: postgresMigrationsFolder }
       );
     } else {
       console.log('📊 Running SQLite migrations...');
@@ -65,7 +58,7 @@ async function runMigrations() {
         database as ReturnType<
           typeof import('drizzle-orm/better-sqlite3').drizzle
         >,
-        { migrationsFolder }
+        { migrationsFolder: sqliteMigrationsFolder }
       );
     }
 
@@ -84,6 +77,18 @@ async function runMigrations() {
     );
     if (connectionTest.version) {
       console.log(`  Spatial Version: ${connectionTest.version}`);
+    }
+
+    if (!connectionTest.connected) {
+      throw new Error('Database connection check failed after migration');
+    }
+
+    if (
+      isPostgres &&
+      config.database.spatialSupport &&
+      !connectionTest.spatialSupport
+    ) {
+      throw new Error('PostGIS verification failed after migration');
     }
 
     process.exit(0);

--- a/src/db/migrations/postgres/0000_postgres_production_baseline.sql
+++ b/src/db/migrations/postgres/0000_postgres_production_baseline.sql
@@ -1,0 +1,517 @@
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS communities (
+  id serial PRIMARY KEY,
+  name text NOT NULL,
+  description text,
+  slug text NOT NULL,
+  public_stories boolean NOT NULL DEFAULT false,
+  locale text NOT NULL DEFAULT 'en',
+  cultural_settings text,
+  is_active boolean NOT NULL DEFAULT true,
+  country text,
+  beta boolean NOT NULL DEFAULT false,
+  created_at timestamp NOT NULL DEFAULT now(),
+  updated_at timestamp NOT NULL DEFAULT now()
+);
+--> statement-breakpoint
+ALTER TABLE communities ADD COLUMN IF NOT EXISTS locale text NOT NULL DEFAULT 'en';
+--> statement-breakpoint
+ALTER TABLE communities ADD COLUMN IF NOT EXISTS cultural_settings text;
+--> statement-breakpoint
+ALTER TABLE communities ADD COLUMN IF NOT EXISTS is_active boolean NOT NULL DEFAULT true;
+--> statement-breakpoint
+ALTER TABLE communities ADD COLUMN IF NOT EXISTS country text;
+--> statement-breakpoint
+ALTER TABLE communities ADD COLUMN IF NOT EXISTS beta boolean NOT NULL DEFAULT false;
+--> statement-breakpoint
+ALTER TABLE communities ALTER COLUMN created_at SET DEFAULT now();
+--> statement-breakpoint
+ALTER TABLE communities ALTER COLUMN updated_at SET DEFAULT now();
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS communities_slug_unique ON communities (slug);
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'communities_country_iso_check'
+  ) THEN
+    ALTER TABLE communities
+      ADD CONSTRAINT communities_country_iso_check
+      CHECK (country IS NULL OR (char_length(country) = 2 AND country = upper(country)));
+  END IF;
+END $$;
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS users (
+  id serial PRIMARY KEY,
+  email text NOT NULL,
+  password_hash text NOT NULL,
+  first_name text NOT NULL,
+  last_name text NOT NULL,
+  role text NOT NULL DEFAULT 'viewer',
+  community_id integer NOT NULL,
+  is_active boolean NOT NULL DEFAULT true,
+  last_login_at timestamp,
+  reset_password_token text,
+  reset_password_sent_at timestamp,
+  remember_created_at timestamp,
+  sign_in_count integer NOT NULL DEFAULT 0,
+  last_sign_in_at timestamp,
+  current_sign_in_ip text,
+  created_at timestamp NOT NULL DEFAULT now(),
+  updated_at timestamp NOT NULL DEFAULT now()
+);
+--> statement-breakpoint
+ALTER TABLE users ADD COLUMN IF NOT EXISTS reset_password_token text;
+--> statement-breakpoint
+ALTER TABLE users ADD COLUMN IF NOT EXISTS reset_password_sent_at timestamp;
+--> statement-breakpoint
+ALTER TABLE users ADD COLUMN IF NOT EXISTS remember_created_at timestamp;
+--> statement-breakpoint
+ALTER TABLE users ADD COLUMN IF NOT EXISTS sign_in_count integer NOT NULL DEFAULT 0;
+--> statement-breakpoint
+ALTER TABLE users ADD COLUMN IF NOT EXISTS last_sign_in_at timestamp;
+--> statement-breakpoint
+ALTER TABLE users ADD COLUMN IF NOT EXISTS current_sign_in_ip text;
+--> statement-breakpoint
+ALTER TABLE users ALTER COLUMN created_at SET DEFAULT now();
+--> statement-breakpoint
+ALTER TABLE users ALTER COLUMN updated_at SET DEFAULT now();
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS users_email_community_unique ON users (email, community_id);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_users_reset_password_token ON users (reset_password_token) WHERE reset_password_token IS NOT NULL;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_users_community_email ON users (community_id, email);
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'users_community_id_fkey'
+  ) THEN
+    ALTER TABLE users
+      ADD CONSTRAINT users_community_id_fkey
+      FOREIGN KEY (community_id) REFERENCES communities(id);
+  END IF;
+END $$;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'users_role_check'
+  ) THEN
+    ALTER TABLE users
+      ADD CONSTRAINT users_role_check
+      CHECK (role IN ('super_admin', 'admin', 'editor', 'elder', 'viewer'));
+  END IF;
+END $$;
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS places (
+  id serial PRIMARY KEY,
+  name text NOT NULL,
+  description text,
+  community_id integer NOT NULL,
+  latitude real NOT NULL,
+  longitude real NOT NULL,
+  region text,
+  media_urls jsonb DEFAULT '[]'::jsonb,
+  photo_url text,
+  cultural_significance text,
+  is_restricted boolean NOT NULL DEFAULT false,
+  created_at timestamp NOT NULL DEFAULT now(),
+  updated_at timestamp NOT NULL DEFAULT now()
+);
+--> statement-breakpoint
+ALTER TABLE places ADD COLUMN IF NOT EXISTS media_urls jsonb DEFAULT '[]'::jsonb;
+--> statement-breakpoint
+ALTER TABLE places ADD COLUMN IF NOT EXISTS photo_url text;
+--> statement-breakpoint
+ALTER TABLE places ADD COLUMN IF NOT EXISTS cultural_significance text;
+--> statement-breakpoint
+ALTER TABLE places ADD COLUMN IF NOT EXISTS is_restricted boolean NOT NULL DEFAULT false;
+--> statement-breakpoint
+ALTER TABLE places ADD COLUMN IF NOT EXISTS location geometry(Point, 4326)
+  GENERATED ALWAYS AS (
+    ST_SetSRID(ST_MakePoint(longitude::double precision, latitude::double precision), 4326)
+  ) STORED;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS places_community_id_idx ON places (community_id);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS places_photo_url_idx ON places (photo_url);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS places_location_gist_idx ON places USING gist (location);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS places_location_geography_gist_idx ON places USING gist ((location::geography));
+--> statement-breakpoint
+ALTER TABLE places ALTER COLUMN created_at SET DEFAULT now();
+--> statement-breakpoint
+ALTER TABLE places ALTER COLUMN updated_at SET DEFAULT now();
+--> statement-breakpoint
+DO $places_fk$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'places_community_id_fkey'
+  ) THEN
+    ALTER TABLE places
+      ADD CONSTRAINT places_community_id_fkey
+      FOREIGN KEY (community_id) REFERENCES communities(id);
+  END IF;
+END $places_fk$;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'places_latitude_check'
+  ) THEN
+    ALTER TABLE places
+      ADD CONSTRAINT places_latitude_check CHECK (latitude BETWEEN -90 AND 90);
+  END IF;
+END $$;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'places_longitude_check'
+  ) THEN
+    ALTER TABLE places
+      ADD CONSTRAINT places_longitude_check CHECK (longitude BETWEEN -180 AND 180);
+  END IF;
+END $$;
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS speakers (
+  id serial PRIMARY KEY,
+  name text NOT NULL,
+  bio text,
+  community_id integer NOT NULL,
+  photo_url text,
+  bio_audio_url text,
+  birth_year integer,
+  elder_status boolean NOT NULL DEFAULT false,
+  cultural_role text,
+  is_active boolean NOT NULL DEFAULT true,
+  created_at timestamp NOT NULL DEFAULT now(),
+  updated_at timestamp NOT NULL DEFAULT now()
+);
+--> statement-breakpoint
+ALTER TABLE speakers ADD COLUMN IF NOT EXISTS bio_audio_url text;
+--> statement-breakpoint
+ALTER TABLE speakers ADD COLUMN IF NOT EXISTS elder_status boolean NOT NULL DEFAULT false;
+--> statement-breakpoint
+ALTER TABLE speakers ADD COLUMN IF NOT EXISTS cultural_role text;
+--> statement-breakpoint
+ALTER TABLE speakers ADD COLUMN IF NOT EXISTS is_active boolean NOT NULL DEFAULT true;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS speakers_community_id_idx ON speakers (community_id);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS speakers_bio_audio_url_idx ON speakers (bio_audio_url);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS speakers_elder_status_idx ON speakers (elder_status);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS speakers_cultural_role_idx ON speakers (cultural_role);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS speakers_is_active_idx ON speakers (is_active);
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'speakers_community_id_fkey'
+  ) THEN
+    ALTER TABLE speakers
+      ADD CONSTRAINT speakers_community_id_fkey
+      FOREIGN KEY (community_id) REFERENCES communities(id);
+  END IF;
+END $$;
+--> statement-breakpoint
+ALTER TABLE speakers ALTER COLUMN created_at SET DEFAULT now();
+--> statement-breakpoint
+ALTER TABLE speakers ALTER COLUMN updated_at SET DEFAULT now();
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS stories (
+  id serial PRIMARY KEY,
+  title text NOT NULL,
+  description text,
+  slug text NOT NULL,
+  community_id integer NOT NULL,
+  created_by integer NOT NULL,
+  is_restricted boolean NOT NULL DEFAULT false,
+  privacy_level text NOT NULL DEFAULT 'public',
+  media_urls jsonb DEFAULT '[]'::jsonb,
+  image_url text,
+  audio_url text,
+  language text NOT NULL DEFAULT 'en',
+  tags jsonb DEFAULT '[]'::jsonb,
+  date_interviewed timestamp,
+  interview_location_id integer,
+  interviewer_id integer,
+  created_at timestamp NOT NULL DEFAULT now(),
+  updated_at timestamp NOT NULL DEFAULT now()
+);
+--> statement-breakpoint
+ALTER TABLE stories ADD COLUMN IF NOT EXISTS privacy_level text NOT NULL DEFAULT 'public';
+--> statement-breakpoint
+ALTER TABLE stories ADD COLUMN IF NOT EXISTS media_urls jsonb DEFAULT '[]'::jsonb;
+--> statement-breakpoint
+ALTER TABLE stories ADD COLUMN IF NOT EXISTS image_url text;
+--> statement-breakpoint
+ALTER TABLE stories ADD COLUMN IF NOT EXISTS audio_url text;
+--> statement-breakpoint
+ALTER TABLE stories ADD COLUMN IF NOT EXISTS language text NOT NULL DEFAULT 'en';
+--> statement-breakpoint
+ALTER TABLE stories ADD COLUMN IF NOT EXISTS tags jsonb DEFAULT '[]'::jsonb;
+--> statement-breakpoint
+ALTER TABLE stories ADD COLUMN IF NOT EXISTS date_interviewed timestamp;
+--> statement-breakpoint
+ALTER TABLE stories ADD COLUMN IF NOT EXISTS interview_location_id integer;
+--> statement-breakpoint
+ALTER TABLE stories ADD COLUMN IF NOT EXISTS interviewer_id integer;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS stories_community_id_idx ON stories (community_id);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS stories_slug_idx ON stories (slug);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS stories_image_url_idx ON stories (image_url);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS stories_audio_url_idx ON stories (audio_url);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS stories_privacy_level_idx ON stories (privacy_level);
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'stories_community_id_fkey'
+  ) THEN
+    ALTER TABLE stories
+      ADD CONSTRAINT stories_community_id_fkey
+      FOREIGN KEY (community_id) REFERENCES communities(id);
+  END IF;
+END $$;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'stories_created_by_fkey'
+  ) THEN
+    ALTER TABLE stories
+      ADD CONSTRAINT stories_created_by_fkey
+      FOREIGN KEY (created_by) REFERENCES users(id);
+  END IF;
+END $$;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'stories_interview_location_id_fkey'
+  ) THEN
+    ALTER TABLE stories
+      ADD CONSTRAINT stories_interview_location_id_fkey
+      FOREIGN KEY (interview_location_id) REFERENCES places(id);
+  END IF;
+END $$;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'stories_interviewer_id_fkey'
+  ) THEN
+    ALTER TABLE stories
+      ADD CONSTRAINT stories_interviewer_id_fkey
+      FOREIGN KEY (interviewer_id) REFERENCES speakers(id);
+  END IF;
+END $$;
+--> statement-breakpoint
+ALTER TABLE stories ALTER COLUMN created_at SET DEFAULT now();
+--> statement-breakpoint
+ALTER TABLE stories ALTER COLUMN updated_at SET DEFAULT now();
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS files (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  filename text NOT NULL,
+  original_name text NOT NULL,
+  path text NOT NULL,
+  url text NOT NULL,
+  mime_type text NOT NULL,
+  size bigint NOT NULL,
+  community_id integer NOT NULL,
+  uploaded_by integer NOT NULL,
+  metadata jsonb,
+  cultural_restrictions jsonb,
+  is_active boolean NOT NULL DEFAULT true,
+  created_at timestamp NOT NULL DEFAULT now(),
+  updated_at timestamp NOT NULL DEFAULT now()
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS files_community_idx ON files (community_id);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS files_user_idx ON files (uploaded_by);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS files_mime_type_idx ON files (mime_type);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS files_active_idx ON files (is_active);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS files_created_at_idx ON files (created_at);
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'files_community_id_fkey'
+  ) THEN
+    ALTER TABLE files
+      ADD CONSTRAINT files_community_id_fkey
+      FOREIGN KEY (community_id) REFERENCES communities(id);
+  END IF;
+END $$;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'files_uploaded_by_fkey'
+  ) THEN
+    ALTER TABLE files
+      ADD CONSTRAINT files_uploaded_by_fkey
+      FOREIGN KEY (uploaded_by) REFERENCES users(id);
+  END IF;
+END $$;
+--> statement-breakpoint
+ALTER TABLE files ALTER COLUMN id SET DEFAULT gen_random_uuid();
+--> statement-breakpoint
+ALTER TABLE files ALTER COLUMN created_at SET DEFAULT now();
+--> statement-breakpoint
+ALTER TABLE files ALTER COLUMN updated_at SET DEFAULT now();
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS story_places (
+  id serial PRIMARY KEY,
+  story_id integer NOT NULL,
+  place_id integer NOT NULL,
+  cultural_context text,
+  sort_order integer DEFAULT 0,
+  created_at timestamp NOT NULL DEFAULT now(),
+  updated_at timestamp NOT NULL DEFAULT now()
+);
+--> statement-breakpoint
+ALTER TABLE story_places ADD COLUMN IF NOT EXISTS cultural_context text;
+--> statement-breakpoint
+ALTER TABLE story_places ADD COLUMN IF NOT EXISTS sort_order integer DEFAULT 0;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS story_place_unique ON story_places (story_id, place_id);
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'story_places_story_id_fkey'
+  ) THEN
+    ALTER TABLE story_places
+      ADD CONSTRAINT story_places_story_id_fkey
+      FOREIGN KEY (story_id) REFERENCES stories(id) ON DELETE CASCADE;
+  END IF;
+END $$;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'story_places_place_id_fkey'
+  ) THEN
+    ALTER TABLE story_places
+      ADD CONSTRAINT story_places_place_id_fkey
+      FOREIGN KEY (place_id) REFERENCES places(id) ON DELETE CASCADE;
+  END IF;
+END $$;
+--> statement-breakpoint
+ALTER TABLE story_places ALTER COLUMN created_at SET DEFAULT now();
+--> statement-breakpoint
+ALTER TABLE story_places ALTER COLUMN updated_at SET DEFAULT now();
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS story_speakers (
+  id serial PRIMARY KEY,
+  story_id integer NOT NULL,
+  speaker_id integer NOT NULL,
+  story_role text,
+  sort_order integer DEFAULT 0,
+  created_at timestamp NOT NULL DEFAULT now(),
+  updated_at timestamp NOT NULL DEFAULT now()
+);
+--> statement-breakpoint
+ALTER TABLE story_speakers ADD COLUMN IF NOT EXISTS story_role text;
+--> statement-breakpoint
+ALTER TABLE story_speakers ADD COLUMN IF NOT EXISTS sort_order integer DEFAULT 0;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS story_speaker_unique ON story_speakers (story_id, speaker_id);
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'story_speakers_story_id_fkey'
+  ) THEN
+    ALTER TABLE story_speakers
+      ADD CONSTRAINT story_speakers_story_id_fkey
+      FOREIGN KEY (story_id) REFERENCES stories(id) ON DELETE CASCADE;
+  END IF;
+END $$;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'story_speakers_speaker_id_fkey'
+  ) THEN
+    ALTER TABLE story_speakers
+      ADD CONSTRAINT story_speakers_speaker_id_fkey
+      FOREIGN KEY (speaker_id) REFERENCES speakers(id) ON DELETE CASCADE;
+  END IF;
+END $$;
+--> statement-breakpoint
+ALTER TABLE story_speakers ALTER COLUMN created_at SET DEFAULT now();
+--> statement-breakpoint
+ALTER TABLE story_speakers ALTER COLUMN updated_at SET DEFAULT now();
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS themes (
+  id serial PRIMARY KEY,
+  name text NOT NULL,
+  description text,
+  mapbox_style_url text,
+  mapbox_access_token text,
+  center_lat numeric(10, 6),
+  center_long numeric(10, 6),
+  sw_boundary_lat numeric(10, 6),
+  sw_boundary_long numeric(10, 6),
+  ne_boundary_lat numeric(10, 6),
+  ne_boundary_long numeric(10, 6),
+  active boolean NOT NULL DEFAULT false,
+  community_id bigint NOT NULL,
+  created_at timestamp NOT NULL DEFAULT now(),
+  updated_at timestamp NOT NULL DEFAULT now()
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_themes_community_id ON themes (community_id);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_themes_active ON themes (active);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_themes_name ON themes (name);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS idx_themes_community_active ON themes (community_id, active);
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'themes_community_id_fkey'
+  ) THEN
+    ALTER TABLE themes
+      ADD CONSTRAINT themes_community_id_fkey
+      FOREIGN KEY (community_id) REFERENCES communities(id);
+  END IF;
+END $$;
+--> statement-breakpoint
+ALTER TABLE themes ALTER COLUMN created_at SET DEFAULT now();
+--> statement-breakpoint
+ALTER TABLE themes ALTER COLUMN updated_at SET DEFAULT now();
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS attachments (
+  id serial PRIMARY KEY,
+  attachable_id integer NOT NULL,
+  attachable_type text NOT NULL,
+  url text NOT NULL,
+  filename text NOT NULL,
+  content_type text,
+  file_size integer,
+  created_at timestamp NOT NULL DEFAULT now()
+);
+--> statement-breakpoint
+ALTER TABLE attachments ALTER COLUMN created_at SET DEFAULT now();

--- a/src/db/migrations/postgres/meta/_journal.json
+++ b/src/db/migrations/postgres/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1786842000000,
+      "tag": "0000_postgres_production_baseline",
+      "breakpoints": true
+    }
+  ]
+}

--- a/src/db/schema/places.ts
+++ b/src/db/schema/places.ts
@@ -248,7 +248,7 @@ export const spatialHelpers = {
     const validLat = validateCoordinate(lat, 'latitude');
     const validLng = validateCoordinate(lng, 'longitude');
     const validRadius = validateRadius(radiusMeters);
-    return `ST_DWithin(ST_SetSRID(ST_MakePoint(longitude, latitude), 4326)::geography, ST_SetSRID(ST_MakePoint(${validLng}, ${validLat}), 4326)::geography, ${validRadius})`;
+    return `ST_DWithin(location::geography, ST_SetSRID(ST_MakePoint(${validLng}, ${validLat}), 4326)::geography, ${validRadius})`;
   },
 
   /**
@@ -285,7 +285,7 @@ export const spatialHelpers = {
   calculateDistance: (fromLat: number, fromLng: number) => {
     const validFromLat = validateCoordinate(fromLat, 'latitude');
     const validFromLng = validateCoordinate(fromLng, 'longitude');
-    return `ST_Distance(ST_SetSRID(ST_MakePoint(longitude, latitude), 4326)::geography, ST_SetSRID(ST_MakePoint(${validFromLng}, ${validFromLat}), 4326)::geography)`;
+    return `ST_Distance(location::geography, ST_SetSRID(ST_MakePoint(${validFromLng}, ${validFromLat}), 4326)::geography)`;
   },
 };
 

--- a/src/repositories/place.repository.ts
+++ b/src/repositories/place.repository.ts
@@ -413,7 +413,9 @@ export class PlaceRepository {
 
     if (this.isPostgres) {
       // Use PostGIS for PostgreSQL
-      const distanceCondition = sql`${spatialHelpers.findWithinRadius(latitude, longitude, radiusMeters)}`;
+      const distanceCondition = sql.raw(
+        spatialHelpers.findWithinRadius(latitude, longitude, radiusMeters)
+      );
 
       let whereCondition = and(
         eq(placesTable.communityId, communityId),
@@ -443,10 +445,9 @@ export class PlaceRepository {
                 'function'
             )
           ) as { [K in keyof Place]: any }),
-          distance:
-            sql<number>`${spatialHelpers.calculateDistance(latitude, longitude)}`.as(
-              'distance'
-            ),
+          distance: sql
+            .raw(spatialHelpers.calculateDistance(latitude, longitude))
+            .as('distance'),
         })
         .from(placesTable)
         .where(whereCondition)

--- a/tests/fixtures/postgres/previous-release-schema.sql
+++ b/tests/fixtures/postgres/previous-release-schema.sql
@@ -1,0 +1,130 @@
+CREATE TABLE communities (
+  id serial PRIMARY KEY,
+  name text NOT NULL,
+  description text,
+  slug text NOT NULL,
+  public_stories boolean NOT NULL DEFAULT false,
+  country text,
+  beta boolean NOT NULL DEFAULT false,
+  created_at timestamp NOT NULL,
+  updated_at timestamp NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE users (
+  id serial PRIMARY KEY,
+  email text NOT NULL,
+  password_hash text NOT NULL,
+  first_name text NOT NULL,
+  last_name text NOT NULL,
+  role text NOT NULL DEFAULT 'viewer',
+  community_id integer NOT NULL,
+  is_active boolean NOT NULL DEFAULT true,
+  last_login_at timestamp,
+  reset_password_token text,
+  reset_password_sent_at timestamp,
+  remember_created_at timestamp,
+  sign_in_count integer NOT NULL DEFAULT 0,
+  last_sign_in_at timestamp,
+  current_sign_in_ip text,
+  created_at timestamp NOT NULL,
+  updated_at timestamp NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE places (
+  id serial PRIMARY KEY,
+  name text NOT NULL,
+  description text,
+  community_id integer NOT NULL,
+  latitude real NOT NULL,
+  longitude real NOT NULL,
+  region text,
+  is_restricted boolean NOT NULL DEFAULT false,
+  created_at timestamp NOT NULL,
+  updated_at timestamp NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE speakers (
+  id serial PRIMARY KEY,
+  name text NOT NULL,
+  bio text,
+  community_id integer NOT NULL,
+  photo_url text,
+  birth_year integer,
+  elder_status boolean NOT NULL DEFAULT false,
+  created_at timestamp NOT NULL,
+  updated_at timestamp NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE stories (
+  id serial PRIMARY KEY,
+  title text NOT NULL,
+  description text,
+  slug text NOT NULL,
+  community_id integer NOT NULL,
+  created_by integer NOT NULL,
+  is_restricted boolean NOT NULL DEFAULT false,
+  created_at timestamp NOT NULL,
+  updated_at timestamp NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE files (
+  id uuid PRIMARY KEY,
+  filename text NOT NULL,
+  original_name text NOT NULL,
+  path text NOT NULL,
+  url text NOT NULL,
+  mime_type text NOT NULL,
+  size bigint NOT NULL,
+  community_id integer NOT NULL,
+  uploaded_by integer NOT NULL,
+  metadata jsonb,
+  cultural_restrictions jsonb,
+  is_active boolean NOT NULL DEFAULT true,
+  created_at timestamp NOT NULL,
+  updated_at timestamp NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE story_places (
+  id serial PRIMARY KEY,
+  story_id integer NOT NULL,
+  place_id integer NOT NULL,
+  created_at timestamp NOT NULL,
+  updated_at timestamp NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE story_speakers (
+  id serial PRIMARY KEY,
+  story_id integer NOT NULL,
+  speaker_id integer NOT NULL,
+  created_at timestamp NOT NULL,
+  updated_at timestamp NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE themes (
+  id serial PRIMARY KEY,
+  name text NOT NULL,
+  description text,
+  mapbox_style_url text,
+  mapbox_access_token text,
+  center_lat numeric(10, 6),
+  center_long numeric(10, 6),
+  sw_boundary_lat numeric(10, 6),
+  sw_boundary_long numeric(10, 6),
+  ne_boundary_lat numeric(10, 6),
+  ne_boundary_long numeric(10, 6),
+  active boolean NOT NULL DEFAULT false,
+  community_id bigint NOT NULL,
+  created_at timestamp NOT NULL,
+  updated_at timestamp NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE attachments (
+  id serial PRIMARY KEY,
+  attachable_id integer NOT NULL,
+  attachable_type text NOT NULL,
+  url text NOT NULL,
+  filename text NOT NULL,
+  content_type text,
+  file_size integer,
+  created_at timestamp NOT NULL
+);

--- a/tests/fixtures/postgres/production-like-data.sql
+++ b/tests/fixtures/postgres/production-like-data.sql
@@ -1,0 +1,168 @@
+INSERT INTO communities (
+  id, name, description, slug, public_stories, country, beta, created_at, updated_at
+) VALUES (
+  1,
+  'Legacy Community',
+  'Production-like migration fixture',
+  'legacy-community',
+  false,
+  'BR',
+  true,
+  '2024-01-10 12:00:00',
+  '2025-06-15 09:30:00'
+);
+--> statement-breakpoint
+INSERT INTO users (
+  id, email, password_hash, first_name, last_name, role, community_id,
+  is_active, last_login_at, reset_password_token, reset_password_sent_at,
+  remember_created_at, sign_in_count, last_sign_in_at, current_sign_in_ip,
+  created_at, updated_at
+) VALUES (
+  1,
+  'admin@example.test',
+  '[REDACTED_HASH]',
+  'Migration',
+  'Admin',
+  'admin',
+  1,
+  true,
+  '2025-06-14 09:00:00',
+  '[REDACTED_TOKEN]',
+  '2025-06-13 08:00:00',
+  '2025-06-12 07:00:00',
+  7,
+  '2025-06-14 09:00:00',
+  '192.0.2.10',
+  '2024-01-10 12:05:00',
+  '2025-06-15 09:35:00'
+);
+--> statement-breakpoint
+INSERT INTO places (
+  id, name, description, community_id, latitude, longitude, region,
+  is_restricted, created_at, updated_at
+) VALUES
+  (
+    1, 'Sacred Site', 'Restricted cultural place', 1,
+    -1.4558, -48.4902, 'Belem', true,
+    '2024-02-01 10:00:00', '2025-06-01 10:00:00'
+  ),
+  (
+    2, 'Community Center', 'Public community place', 1,
+    -1.4562, -48.4895, 'Belem', false,
+    '2024-02-02 10:00:00', '2025-06-02 10:00:00'
+  ),
+  (
+    3, 'Far Site', 'Outside local search radius', 1,
+    -3.1190, -60.0217, 'Manaus', false,
+    '2024-02-03 10:00:00', '2025-06-03 10:00:00'
+  );
+--> statement-breakpoint
+INSERT INTO speakers (
+  id, name, bio, community_id, photo_url, birth_year, elder_status,
+  created_at, updated_at
+) VALUES (
+  1,
+  'Elder Speaker',
+  'Knowledge holder',
+  1,
+  'https://example.test/elder.jpg',
+  1950,
+  true,
+  '2024-03-01 10:00:00',
+  '2025-06-04 10:00:00'
+);
+--> statement-breakpoint
+INSERT INTO stories (
+  id, title, description, slug, community_id, created_by, is_restricted,
+  created_at, updated_at
+) VALUES (
+  1,
+  'Restricted Story',
+  'Story preserving a restricted migration invariant',
+  'restricted-story',
+  1,
+  1,
+  true,
+  '2024-04-01 10:00:00',
+  '2025-06-05 10:00:00'
+);
+--> statement-breakpoint
+INSERT INTO files (
+  id, filename, original_name, path, url, mime_type, size,
+  community_id, uploaded_by, metadata, cultural_restrictions, is_active,
+  created_at, updated_at
+) VALUES (
+  '11111111-1111-4111-8111-111111111111',
+  'elder-audio.mp3',
+  'elder interview.mp3',
+  'communities/1/stories/1/elder-audio.mp3',
+  'https://example.test/files/elder-audio.mp3',
+  'audio/mpeg',
+  4096,
+  1,
+  1,
+  '{"duration": 42}',
+  '{"elderOnly": true, "accessLevel": "community"}',
+  true,
+  '2024-04-02 10:00:00',
+  '2025-06-06 10:00:00'
+);
+--> statement-breakpoint
+INSERT INTO story_places (
+  id, story_id, place_id, created_at, updated_at
+) VALUES (
+  1, 1, 1, '2024-04-03 10:00:00', '2025-06-07 10:00:00'
+);
+--> statement-breakpoint
+INSERT INTO story_speakers (
+  id, story_id, speaker_id, created_at, updated_at
+) VALUES (
+  1, 1, 1, '2024-04-04 10:00:00', '2025-06-08 10:00:00'
+);
+--> statement-breakpoint
+INSERT INTO themes (
+  id, name, description, center_lat, center_long, active, community_id,
+  created_at, updated_at
+) VALUES (
+  1,
+  'Legacy Theme',
+  'Theme retained through upgrade',
+  -1.455800,
+  -48.490200,
+  true,
+  1,
+  '2024-05-01 10:00:00',
+  '2025-06-09 10:00:00'
+);
+--> statement-breakpoint
+INSERT INTO attachments (
+  id, attachable_id, attachable_type, url, filename, content_type, file_size,
+  created_at
+) VALUES (
+  1,
+  1,
+  'Story',
+  'https://example.test/attachments/story-photo.jpg',
+  'story-photo.jpg',
+  'image/jpeg',
+  2048,
+  '2024-05-02 10:00:00'
+);
+--> statement-breakpoint
+SELECT setval(pg_get_serial_sequence('communities', 'id'), 1, true);
+--> statement-breakpoint
+SELECT setval(pg_get_serial_sequence('users', 'id'), 1, true);
+--> statement-breakpoint
+SELECT setval(pg_get_serial_sequence('places', 'id'), 3, true);
+--> statement-breakpoint
+SELECT setval(pg_get_serial_sequence('speakers', 'id'), 1, true);
+--> statement-breakpoint
+SELECT setval(pg_get_serial_sequence('stories', 'id'), 1, true);
+--> statement-breakpoint
+SELECT setval(pg_get_serial_sequence('story_places', 'id'), 1, true);
+--> statement-breakpoint
+SELECT setval(pg_get_serial_sequence('story_speakers', 'id'), 1, true);
+--> statement-breakpoint
+SELECT setval(pg_get_serial_sequence('themes', 'id'), 1, true);
+--> statement-breakpoint
+SELECT setval(pg_get_serial_sequence('attachments', 'id'), 1, true);


### PR DESCRIPTION
### **User description**
Closes #135

## Summary
- add a dedicated PostgreSQL 13/PostGIS CI job for every PR and push to main
- add a reviewed PostgreSQL production migration history separate from SQLite
- validate fresh installs, previous-release upgrades, production-like data preservation, fail-closed migrations, real PostGIS queries, GiST index use, and repository behavior
- make PostgreSQL migration/PostGIS verification fail closed and fix postgres-js connection verification
- fix production radius queries to execute validated PostGIS SQL and use an indexable generated location column
- package migration assets in the production image and run the compiled migrator before startup
- document local reproduction, sanitized fixtures, migration safety, and expand-contract policy

## Validation
- `npm run test:postgres` — 4/4 production database gates pass against `postgis/postgis:13-master`
- `npm run type-check` — pass
- `npm run lint` — pass (existing warning baseline only)
- `npm run build` — pass
- targeted Prettier check for all touched supported files — pass
- `npx vitest run tests/repositories/place.repository.test.ts tests/production/infrastructure.test.ts` — 44/44 pass
- production Docker image builds successfully
- compiled migrator runs successfully from the production image against PostgreSQL/PostGIS
- production image migration + API startup sequence reaches ready state and shuts down gracefully

## Migration safety
The PostgreSQL gate is destructive only against explicitly acknowledged test databases. It proves a failed upgrade is not recorded, preserves representative ownership/restriction/auth/file/join invariants, verifies constraints/defaults/timestamps, and exercises the actual spatial index plan. Production migrations fail if PostGIS cannot be enabled or verified.


___

### **PR Type**
Enhancement, Tests, Documentation, Bug fix


___

### **Description**
- Add mandatory PostgreSQL/PostGIS CI workflow

- Introduce reviewed PostgreSQL migration history

- Enforce fail-closed PostGIS verification

- Align spatial queries with generated geometry


___

### Diagram Walkthrough


```mermaid
flowchart LR
  CI["GitHub Actions: PostgreSQL/PostGIS"] -- "runs" --> Gate["scripts/test-postgres-ci.ts gate"]
  Gate -- "executes" --> Migrator["migrate.ts fail-closed logic"]
  Migrator -- "applies" --> PgMigs["PostgreSQL migration history"]
  Gate -- "verifies" --> Repo["PlaceRepository PostGIS queries"]
  Docker["Docker/Compose startup"] -- "runs compiled migrator" --> Migrator
  Docs["Docs: postgresql-postgis-ci.md"] -- "guides reproduction" --> CI
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>test-postgres-ci.ts</strong><dd><code>Add PostgreSQL/PostGIS integration gate and assertions</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Terrastories/terrastories-api/pull/151/files#diff-ae8e9b5c03c30a75522a066f7d01d5205a2df201fca01a739934235d58cc4a4d">+565/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>package.json</strong><dd><code>Add npm script for PostgreSQL gate</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Terrastories/terrastories-api/pull/151/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>previous-release-schema.sql</strong><dd><code>Add previous-release schema fixture for upgrades</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Terrastories/terrastories-api/pull/151/files#diff-d59d2e86badc34f4e194fb8ab306227f507912133a5067924d949693f070adcf">+130/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>production-like-data.sql</strong><dd><code>Add production-like sanitized data fixture</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Terrastories/terrastories-api/pull/151/files#diff-22551fc945b6cd32f0b20c2f2d08b1f0b5f20a0b497ff11064a85ea05c29b61a">+168/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>index.ts</strong><dd><code>Fix PostGIS version result row handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Terrastories/terrastories-api/pull/151/files#diff-c7d2c320d1f7fc0aad36b8bf616a7289ca4dcf00e6e057ba8a1d354fb25b74c0">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>migrate.ts</strong><dd><code>Split migrations; enforce PostGIS and post-checks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Terrastories/terrastories-api/pull/151/files#diff-bb9767c8cf112f92e234e71d3f5f8c95a4b6047ec2fe74ad5866b517ab43657e">+27/-22</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>places.ts</strong><dd><code>Use generated location column for PostGIS</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Terrastories/terrastories-api/pull/151/files#diff-93ce6052a362953c59299abcec641f2ee85468e20ec50b7c433c66df0d3f2600">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>place.repository.ts</strong><dd><code>Switch to raw PostGIS expressions in search</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Terrastories/terrastories-api/pull/151/files#diff-b5990af5d43ef665d113f81644b52242f670114520e48910a50865b1beb3315d">+6/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>0000_postgres_production_baseline.sql</strong><dd><code>Add PostgreSQL production baseline schema and indexes</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Terrastories/terrastories-api/pull/151/files#diff-8eed087ae34e7380671c5e65ed6cd787444e4ff269aac81093d6ca70582b5306">+517/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>postgres-postgis.yml</strong><dd><code>Add mandatory PostgreSQL/PostGIS CI workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Terrastories/terrastories-api/pull/151/files#diff-5c9d14bb0eb78bac097bdb87256f823658786b5c7a1a75a1faa1bb1bf9fdc407">+53/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Dockerfile</strong><dd><code>Package SQL migrations in runtime image</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Terrastories/terrastories-api/pull/151/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>docker-compose.prod.yml</strong><dd><code>Run compiled migrator before API startup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Terrastories/terrastories-api/pull/151/files#diff-4563fbe997bbf18c3b38ad79c596c57c3ad88361f1dccb8c4f39b429382c06d3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>_journal.json</strong><dd><code>Add Drizzle migration journal for Postgres</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Terrastories/terrastories-api/pull/151/files#diff-496b394556ec1bc1cbfcf545db454b34a409bd8648c64c3cc7eef4dfba127d7b">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>postgresql-postgis-ci.md</strong><dd><code>Document PostgreSQL/PostGIS gate and policy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/Terrastories/terrastories-api/pull/151/files#diff-0f1993664131178fbc61402ac6913ce1fe06c74602f4638383fc200c5a9b8f58">+77/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

